### PR TITLE
Refactor outputmessage pool

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -33,25 +33,25 @@ extern ConfigManager g_config;
 Connection_ptr ConnectionManager::createConnection(boost::asio::ip::tcp::socket* socket,
         boost::asio::io_service& io_service, ServicePort_ptr servicer)
 {
-	std::lock_guard<std::recursive_mutex> lockClass(m_connectionManagerLock);
+	std::lock_guard<std::mutex> lockClass(m_connectionManagerLock);
 
-	Connection_ptr connection = std::make_shared<Connection>(socket, io_service, servicer);
+	auto connection = std::make_shared<Connection>(socket, io_service, servicer);
 	m_connections.insert(connection);
 	return connection;
 }
 
-void ConnectionManager::releaseConnection(Connection_ptr connection)
+void ConnectionManager::releaseConnection(const Connection_ptr& connection)
 {
-	std::lock_guard<std::recursive_mutex> lockClass(m_connectionManagerLock);
+	std::lock_guard<std::mutex> lockClass(m_connectionManagerLock);
 
 	m_connections.erase(connection);
 }
 
 void ConnectionManager::closeAll()
 {
-	std::lock_guard<std::recursive_mutex> lockClass(m_connectionManagerLock);
+	std::lock_guard<std::mutex> lockClass(m_connectionManagerLock);
 
-	for (const Connection_ptr& connection : m_connections) {
+	for (const auto& connection : m_connections) {
 		try {
 			boost::system::error_code error;
 			connection->m_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
@@ -67,16 +67,18 @@ void ConnectionManager::closeAll()
 void Connection::close()
 {
 	//any thread
+	auto this_shared = shared_from_this();
+	ConnectionManager::getInstance()->releaseConnection(this_shared);
 	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 
-	if (m_connectionState == CONNECTION_STATE_CLOSING || m_connectionState == CONNECTION_STATE_CLOSED || m_connectionState == CONNECTION_STATE_REQUEST_CLOSE) {
+	if (m_connectionState != CONNECTION_STATE_OPEN) {
 		return;
 	}
 
-	m_connectionState = CONNECTION_STATE_REQUEST_CLOSE;
+	m_connectionState = CONNECTION_STATE_CLOSED;
 
 	g_dispatcher.addTask(
-	    createTask(std::bind(&Connection::closeConnectionTask, this)));
+	    createTask(std::bind(&Connection::closeConnectionTask, std::move(this_shared))));
 }
 
 void Connection::closeConnectionTask()
@@ -84,23 +86,12 @@ void Connection::closeConnectionTask()
 	//dispatcher thread
 	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 
-	if (m_connectionState != CONNECTION_STATE_REQUEST_CLOSE) {
-		std::cout << "Error: [Connection::closeConnectionTask] m_connectionState = " << m_connectionState << std::endl;
-		return;
-	}
-
 	if (m_protocol) {
-		m_protocol->setConnection(Connection_ptr());
-		m_protocol->releaseProtocol();
-		m_protocol = nullptr;
+		m_protocol->release();
 	}
 
-	m_connectionState = CONNECTION_STATE_CLOSING;
-
-	if (m_pendingWrite == 0 || m_writeError) {
+	if (!m_pendingWrite || m_writeError) {
 		closeSocket();
-		releaseConnection();
-		m_connectionState = CONNECTION_STATE_CLOSED;
 	} else {
 		//will be closed by onWriteOperation/handleWriteTimeout/handleReadTimeout instead
 	}
@@ -108,13 +99,13 @@ void Connection::closeConnectionTask()
 
 void Connection::closeSocket()
 {
-	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
-
 	if (m_socket->is_open()) {
-		m_pendingRead = 0;
-		m_pendingWrite = 0;
+		m_pendingRead = false;
+		m_pendingWrite = false;
 
 		try {
+			m_readTimer.cancel();
+			m_writeTimer.cancel();
 			boost::system::error_code error;
 			m_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
 			m_socket->close(error);
@@ -127,58 +118,12 @@ void Connection::closeSocket()
 	}
 }
 
-void Connection::releaseConnection()
+Connection::~Connection()
 {
-	if (m_refCount > 0) {
-		//Reschedule it and try again.
-		g_scheduler.addEvent(createSchedulerTask(SCHEDULER_MINTICKS, std::bind(&Connection::releaseConnection, this)));
-	} else {
-		deleteConnectionTask();
-	}
+	closeSocket();
 }
 
-void Connection::onStopOperation()
-{
-	//io_service thread
-	m_connectionLock.lock();
-
-	m_readTimer.cancel();
-	m_writeTimer.cancel();
-
-	try {
-		if (m_socket->is_open()) {
-			boost::system::error_code error;
-			m_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
-			m_socket->close();
-		}
-	} catch (boost::system::system_error&) {
-		//
-	}
-
-	delete m_socket;
-	m_socket = nullptr;
-
-	m_connectionLock.unlock();
-
-	ConnectionManager::getInstance()->releaseConnection(shared_from_this());
-}
-
-void Connection::deleteConnectionTask()
-{
-	//dispather thread
-	assert(m_refCount == 0);
-
-	try {
-		m_io_service.dispatch(std::bind(&Connection::onStopOperation, this));
-	} catch (boost::system::system_error& e) {
-		if (m_logError) {
-			std::cout << "[Network error - Connection::deleteConnectionTask] " << e.what() << std::endl;
-			m_logError = false;
-		}
-	}
-}
-
-void Connection::accept(Protocol* protocol)
+void Connection::accept(const Protocol_ptr& protocol)
 {
 	m_protocol = protocol;
 	g_dispatcher.addTask(createTask(std::bind(&Protocol::onConnect, m_protocol)));
@@ -188,13 +133,14 @@ void Connection::accept(Protocol* protocol)
 
 void Connection::accept()
 {
+	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 	try {
-		++m_pendingRead;
+		m_pendingRead = true;
 		m_readTimer.expires_from_now(boost::posix_time::seconds(Connection::read_timeout));
 		m_readTimer.async_wait(std::bind(&Connection::handleReadTimeout, std::weak_ptr<Connection>(shared_from_this()), std::placeholders::_1));
 
 		// Read size of the first packet
-		boost::asio::async_read(getHandle(),
+		boost::asio::async_read(*m_socket,
 		                        boost::asio::buffer(m_msg.getBuffer(), NetworkMessage::header_length),
 		                        std::bind(&Connection::parseHeader, shared_from_this(), std::placeholders::_1));
 	} catch (boost::system::system_error& e) {
@@ -241,7 +187,7 @@ void Connection::parseHeader(const boost::system::error_code& error)
 
 		// Read packet content
 		m_msg.setLength(size + NetworkMessage::header_length);
-		boost::asio::async_read(getHandle(), boost::asio::buffer(m_msg.getBodyBuffer(), size),
+		boost::asio::async_read(*m_socket, boost::asio::buffer(m_msg.getBodyBuffer(), size),
 		                        std::bind(&Connection::parsePacket, shared_from_this(), std::placeholders::_1));
 	} catch (boost::system::system_error& e) {
 		if (m_logError) {
@@ -288,13 +234,12 @@ void Connection::parsePacket(const boost::system::error_code& error)
 
 		if (!m_protocol) {
 			// Game protocol has already been created at this point
-			m_protocol = m_service_port->make_protocol(recvChecksum == checksum, m_msg);
+			m_protocol = m_service_port->make_protocol(recvChecksum == checksum, m_msg, shared_from_this());
 			if (!m_protocol) {
 				close();
 				return;
 			}
 
-			m_protocol->setConnection(shared_from_this());
 		} else {
 			m_msg.getByte();    // Skip protocol ID
 		}
@@ -310,7 +255,7 @@ void Connection::parsePacket(const boost::system::error_code& error)
 		                                    std::placeholders::_1));
 
 		// Wait to the next packet
-		boost::asio::async_read(getHandle(),
+		boost::asio::async_read(*m_socket,
 		                        boost::asio::buffer(m_msg.getBuffer(), NetworkMessage::header_length),
 		                        std::bind(&Connection::parseHeader, shared_from_this(), std::placeholders::_1));
 	} catch (boost::system::system_error& e) {
@@ -323,16 +268,18 @@ void Connection::parsePacket(const boost::system::error_code& error)
 	}
 }
 
-bool Connection::send(OutputMessage_ptr msg)
+bool Connection::send(const OutputMessage_ptr& msg)
 {
 	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
-
 	if (m_connectionState != CONNECTION_STATE_OPEN || m_writeError) {
+		if (m_protocol) {
+			m_protocol->clearOutputBuffer(msg);
+		}
 		return false;
 	}
 
-	if (m_pendingWrite == 0) {
-		msg->getProtocol()->onSendMessage(msg);
+	if (!m_pendingWrite) {
+		m_protocol->onSendMessage(msg);
 		internalSend(msg);
 	} else {
 		// FIXME: This results in packets being sent in wrong order, all queued
@@ -343,15 +290,15 @@ bool Connection::send(OutputMessage_ptr msg)
 	return true;
 }
 
-void Connection::internalSend(OutputMessage_ptr msg)
+void Connection::internalSend(const OutputMessage_ptr& msg)
 {
 	try {
-		++m_pendingWrite;
+		m_pendingWrite = true;
 		m_writeTimer.expires_from_now(boost::posix_time::seconds(Connection::write_timeout));
 		m_writeTimer.async_wait( std::bind(&Connection::handleWriteTimeout, std::weak_ptr<Connection>(shared_from_this()),
 		                                     std::placeholders::_1));
 
-		boost::asio::async_write(getHandle(),
+		boost::asio::async_write(*m_socket,
 		                         boost::asio::buffer(msg->getOutputBuffer(), msg->getLength()),
 		                         std::bind(&Connection::onWriteOperation, shared_from_this(), msg, std::placeholders::_1));
 	} catch (boost::system::system_error& e) {
@@ -362,8 +309,9 @@ void Connection::internalSend(OutputMessage_ptr msg)
 	}
 }
 
-uint32_t Connection::getIP() const
+uint32_t Connection::getIP()
 {
+	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 	//Ip is expressed in network byte order
 	boost::system::error_code error;
 	const boost::asio::ip::tcp::endpoint endpoint = m_socket->remote_endpoint(error);
@@ -377,10 +325,8 @@ uint32_t Connection::getIP() const
 
 void Connection::onWriteOperation(OutputMessage_ptr msg, const boost::system::error_code& error)
 {
-	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);;
+	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 	m_writeTimer.cancel();
-
-	msg.reset();
 
 	if (error) {
 		handleWriteError(error);
@@ -392,17 +338,14 @@ void Connection::onWriteOperation(OutputMessage_ptr msg, const boost::system::er
 		return;
 	}
 
-	--m_pendingWrite;
+	m_pendingWrite = false;
 }
 
 void Connection::handleReadError(const boost::system::error_code& error)
 {
 	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 
-	if (error == boost::asio::error::operation_aborted) {
-		// Operation aborted because connection will be closed
-		// Do NOT call close() from here
-	} else {
+	if (error != boost::asio::error::operation_aborted) {
 		/**
 		 * error == boost::asio::error::eof:
 		 *  No more to read
@@ -419,7 +362,7 @@ void Connection::onReadTimeout()
 {
 	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 
-	if (m_pendingRead > 0 || m_readError) {
+	if (m_pendingRead || m_readError) {
 		closeSocket();
 		close();
 	}
@@ -429,35 +372,26 @@ void Connection::onWriteTimeout()
 {
 	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
 
-	if (m_pendingWrite > 0 || m_writeError) {
+	if (m_pendingWrite || m_writeError) {
 		closeSocket();
 		close();
 	}
 }
 
-void Connection::handleReadTimeout(std::weak_ptr<Connection> weak_conn, const boost::system::error_code& error)
+void Connection::handleReadTimeout(ConnectionWeak_ptr weak_conn, const boost::system::error_code& error)
 {
 	if (error == boost::asio::error::operation_aborted) {
 		return;
 	}
 
-	if (weak_conn.expired()) {
-		return;
-	}
-
-	if (Connection_ptr connection = weak_conn.lock()) {
+	if (auto connection = weak_conn.lock()) {
 		connection->onReadTimeout();
 	}
 }
 
 void Connection::handleWriteError(const boost::system::error_code& error)
 {
-	std::lock_guard<std::recursive_mutex> lockClass(m_connectionLock);
-
-	if (error == boost::asio::error::operation_aborted) {
-		// Operation aborted because connection will be closed
-		// Do NOT call close() from here
-	} else {
+	if (error != boost::asio::error::operation_aborted) {
 		/**
 		 * error == boost::asio::error::eof:
 		 *  No more to read
@@ -470,17 +404,13 @@ void Connection::handleWriteError(const boost::system::error_code& error)
 	m_writeError = true;
 }
 
-void Connection::handleWriteTimeout(std::weak_ptr<Connection> weak_conn, const boost::system::error_code& error)
+void Connection::handleWriteTimeout(ConnectionWeak_ptr weak_conn, const boost::system::error_code& error)
 {
 	if (error == boost::asio::error::operation_aborted) {
 		return;
 	}
 
-	if (weak_conn.expired()) {
-		return;
-	}
-
-	if (Connection_ptr connection = weak_conn.lock()) {
+	if (auto connection = weak_conn.lock()) {
 		connection->onWriteTimeout();
 	}
 }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -52,7 +52,6 @@ void ConnectionManager::closeAll()
 	std::lock_guard<std::mutex> lockClass(m_connectionManagerLock);
 
 	for (const auto& connection : m_connections) {
-		assert(connection.use_count() == 1);
 		try {
 			boost::system::error_code error;
 			connection->m_socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -341,6 +341,7 @@ void Connection::handleReadError(const boost::system::error_code& error)
 		 *  Connection closed remotely
 		 */
 		close();
+		closeSocket();
 	}
 
 	m_readError = true;
@@ -387,6 +388,7 @@ void Connection::handleWriteError(const boost::system::error_code& error)
 		 *  Connection closed remotely
 		 */
 		close();
+		closeSocket();
 	}
 
 	m_writeError = true;

--- a/src/connection.h
+++ b/src/connection.h
@@ -21,6 +21,7 @@
 #define FS_CONNECTION_H_FC8E1B4392D24D27A2F129D8B93A6348
 
 #include <unordered_set>
+#include <queue>
 
 #include "networkmessage.h"
 
@@ -39,9 +40,9 @@ typedef std::shared_ptr<ServicePort> ServicePort_ptr;
 class ConnectionManager
 {
 	public:
-		static ConnectionManager* getInstance() {
+		static ConnectionManager& getInstance() {
 			static ConnectionManager instance;
-			return &instance;
+			return instance;
 		}
 
 		Connection_ptr createConnection(boost::asio::ip::tcp::socket* socket,
@@ -94,15 +95,13 @@ class Connection : public std::enable_shared_from_this<Connection>
 
 		void close();
 		// Used by protocols that require server to send first
-		void accept(const Protocol_ptr& protocol);
+		void accept(Protocol_ptr protocol);
 		void accept();
 
-		bool send(const OutputMessage_ptr& msg);
+		void send(OutputMessage_ptr msg);
 
 		uint32_t getIP();
-		Protocol_ptr getProtocol() const {
-			return m_protocol;
-		}
+
 	private:
 		void parseHeader(const boost::system::error_code& error);
 		void parsePacket(const boost::system::error_code& error);
@@ -119,7 +118,7 @@ class Connection : public std::enable_shared_from_this<Connection>
 		void onReadTimeout();
 		void onWriteTimeout();
 
-		void internalSend(const OutputMessage_ptr& msg);
+		void internalSend(OutputMessage_ptr msg);
 
 		NetworkMessage m_msg;
 
@@ -127,6 +126,8 @@ class Connection : public std::enable_shared_from_this<Connection>
 		boost::asio::deadline_timer m_writeTimer;
 
 		std::recursive_mutex m_connectionLock;
+
+		std::queue<OutputMessage_ptr> messageQueue;
 
 		ServicePort_ptr m_service_port;
 		Protocol_ptr m_protocol;

--- a/src/connection.h
+++ b/src/connection.h
@@ -109,14 +109,12 @@ class Connection : public std::enable_shared_from_this<Connection>
 
 		void onWriteOperation(OutputMessage_ptr msg, const boost::system::error_code& error);
 
-		void onStopOperation();
 		void handleReadError(const boost::system::error_code& error);
 		void handleWriteError(const boost::system::error_code& error);
 
 		static void handleReadTimeout(ConnectionWeak_ptr weak_conn, const boost::system::error_code& error);
 		static void handleWriteTimeout(ConnectionWeak_ptr weak_conn, const boost::system::error_code& error);
 
-		void closeConnectionTask();
 		void closeSocket();
 		void onReadTimeout();
 		void onWriteTimeout();
@@ -131,9 +129,9 @@ class Connection : public std::enable_shared_from_this<Connection>
 		std::recursive_mutex m_connectionLock;
 
 		ServicePort_ptr m_service_port;
+		Protocol_ptr m_protocol;
 
 		std::unique_ptr<boost::asio::ip::tcp::socket> m_socket;
-		Protocol_ptr m_protocol;
 		boost::asio::io_service& m_io_service;
 
 		time_t m_timeConnected;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4388,7 +4388,7 @@ void Game::shutdown()
 		serviceManager->stop();
 	}
 
-	ConnectionManager::getInstance()->closeAll();
+	ConnectionManager::getInstance().closeAll();
 
 	std::cout << " done!" << std::endl;
 }

--- a/src/lockfree.h
+++ b/src/lockfree.h
@@ -1,0 +1,149 @@
+/**
+ * The Forgotten Server - a free and open-source MMORPG server emulator
+ * Copyright (C) 2015  Mark Samman <mark.samman@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef FS_LOCKFREE_H_8C707AEB7C7235A2FBC5D4EDDF03B008
+#define FS_LOCKFREE_H_8C707AEB7C7235A2FBC5D4EDDF03B008
+
+#include <atomic>
+
+template <typename T, uint16_t CAPACITY>
+class LockfreeBoundedStack {
+	private:
+		struct Node
+		{
+			static constexpr uint16_t END = std::numeric_limits<decltype(CAPACITY)>::max();
+			uint16_t generation = 0;
+			uint16_t index = END;
+			uint16_t nextNode = END;
+			uint16_t unused = 0;
+			operator bool () const noexcept {
+				return index != END;
+			}
+		};
+		static_assert(sizeof(Node) == sizeof(uint64_t), "Invalid node size.");
+		static_assert(CAPACITY != 0 && CAPACITY < Node::END, "Specified capacity out of range.");
+	public:
+		LockfreeBoundedStack() {
+			for (uint16_t i = 0; i < CAPACITY; ++i) {
+				nodes[i].index = i;
+				internal_push(freeNodes, nodes[i]);
+			}
+		}
+
+		LockfreeBoundedStack(const LockfreeBoundedStack&) = delete;
+		LockfreeBoundedStack& operator=(const LockfreeBoundedStack&) = delete;
+
+		bool pop(T& ret) noexcept {
+			if (auto node = internal_pop(head)) {
+				ret = std::move(getPayload(node));
+				internal_push(freeNodes, node);
+				return true;
+			}
+
+			return false; //The stack was empty
+		}
+
+		bool push(T value) noexcept {
+			if (auto node = internal_pop(freeNodes)) {
+				getPayload(node) = value;
+				internal_push(head, node);
+				return true;
+			}
+
+			return false; //Exceeded maximum capacity
+		}
+	private:
+		Node internal_pop(std::atomic<Node>& listHead) noexcept {
+			Node currentHead, nextNode;
+			currentHead = listHead.load(std::memory_order_acquire);
+			do {
+				if (!currentHead) {
+					break;
+				}
+				nextNode = getNextNode(currentHead);
+			} while (!listHead.compare_exchange_weak(currentHead, nextNode,
+								 std::memory_order_release,
+								 std::memory_order_relaxed));
+
+			return currentHead;
+		}
+
+		void internal_push(std::atomic<Node>& listHead, Node newNode) noexcept {
+			auto currentHead = listHead.load(std::memory_order_acquire);
+			newNode.generation++;
+			do {
+				newNode.nextNode = currentHead.index;
+				nodes[newNode.index] = newNode;
+			} while (!listHead.compare_exchange_weak(currentHead, newNode, 
+								 std::memory_order_release,
+								 std::memory_order_relaxed));
+		}
+
+		T& getPayload(Node node) noexcept {
+			return payloads[node.index];
+		}
+
+		Node getNextNode(Node node) const noexcept {
+			if (node.nextNode == Node::END) {
+				return Node();
+			}
+			return nodes[node.nextNode];
+		}
+
+		T payloads[CAPACITY];
+		Node nodes[CAPACITY];
+
+		//TODO: Add padding to prevent these two from being on the same cache line
+		std::atomic<Node> freeNodes;
+		std::atomic<Node> head;
+};
+
+template <typename T>
+class LockfreePoolingAllocator : public std::allocator<T>
+{
+	public:
+		template <typename U>
+		LockfreePoolingAllocator(const U&) {}
+		typedef T value_type;
+
+		T* allocate(size_t) const {
+			T* p;
+			if (!getFreeList().pop(p)) {
+				//Acquire memory without calling the constructor of T
+				p = static_cast<T*>(operator new (sizeof(T)));
+			}
+			return p;
+		}
+
+		void deallocate(T* p, size_t) const {
+			if (!getFreeList().push(p)) {
+				//Release memory without calling the destructor of T
+				//(it has already been called at this point)
+				operator delete(p);
+			}
+		}
+	private:
+		typedef LockfreeBoundedStack<T*, OUTPUTMESSAGE_FREE_LIST_CAPACITY> FreeList;
+		static FreeList& getFreeList() noexcept {
+			static FreeList freeList;
+			return freeList;
+		}
+};
+
+#endif

--- a/src/networkmessage.cpp
+++ b/src/networkmessage.cpp
@@ -74,19 +74,6 @@ void NetworkMessage::addString(const std::string& value)
 	length += stringLen;
 }
 
-void NetworkMessage::addString(const char* value)
-{
-	size_t stringLen = strlen(value);
-	if (!canAdd(stringLen + 2) || stringLen > 8192) {
-		return;
-	}
-
-	add<uint16_t>(stringLen);
-	memcpy(buffer + position, value, stringLen);
-	position += stringLen;
-	length += stringLen;
-}
-
 void NetworkMessage::addDouble(double value, uint8_t precision/* = 2*/)
 {
 	addByte(precision);

--- a/src/outputmessage.cpp
+++ b/src/outputmessage.cpp
@@ -46,14 +46,6 @@ class PoolingAllocator : public std::allocator<T>
 				operator delete(p);
 			}
 		}
-
-		~PoolingAllocator() {
-			T* ptr;
-			auto& freeList = getFreeList();
-			while(freeList.pop(ptr)) {
-				operator delete(ptr);
-			}
-		}
 	private:
 		typedef LockfreeBoundedStack<T*, OUTPUTMESSAGE_FREE_LIST_CAPACITY> FreeList;
 		static FreeList& getFreeList() {

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -23,6 +23,7 @@
 #include "networkmessage.h"
 #include "connection.h"
 #include "tools.h"
+#include <atomic>
 #include <boost/lockfree/stack.hpp>
 
 const uint16_t OUTPUTMESSAGE_FREE_LIST_CAPACITY = 4096;
@@ -42,7 +43,7 @@ class OutputMessage : public NetworkMessage
 			frame(frame),
 			outputBufferStart(INITIAL_BUFFER_POSITION),
 			state(STATE_FREE) {}
-		
+
 		OutputMessage() = delete;
 		// non-copyable
 		OutputMessage(const OutputMessage&) = delete;

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -146,12 +146,7 @@ class LockfreeBoundedStack {
 			return false; //The stack was empty
 		}
 
-		typename std::enable_if<std::is_copy_assignable<T>::value, bool>::type //Disable this overload for non-copyable types using SFINAE
-			push(const T& value) noexcept {
-				return push(value);
-			}
-
-		bool push(T&& value) noexcept {
+		bool push(T value) noexcept {
 			if (auto node = internal_pop(freeNodes)) {
 				getPayload(node) = value;
 				internal_push(head, node);

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -102,103 +102,15 @@ class OutputMessagePool
 
 		static OutputMessage_ptr getOutputMessage();
 
-		void addProtocolToAutosend(Protocol_ptr protocol);
+		void addProtocolToAutosend(Protocol_ptr protocol) {
+			//dispatcher thread
+			bufferedProtocols.emplace_back(protocol);
+		}
 		void removeProtocolFromAutosend(const Protocol_ptr& protocol);
 	private:
 		OutputMessagePool() = default;
 		std::vector<Protocol_ptr> bufferedProtocols;
 };
 
-template <typename T, uint16_t CAPACITY>
-class LockfreeBoundedStack {
-	private:
-		struct Node
-		{
-			static constexpr uint16_t END = std::numeric_limits<decltype(CAPACITY)>::max();
-			uint16_t generation = 0;
-			uint16_t index = END;
-			uint16_t nextNode = END;
-			uint16_t unused = 0;
-			operator bool () const noexcept {
-				return index != END;
-			}
-		};
-		static_assert(sizeof(Node) == sizeof(uint64_t), "Invalid node size.");
-		static_assert(CAPACITY != 0 && CAPACITY < Node::END, "Specified capacity out of range.");
-	public:
-		LockfreeBoundedStack() {
-			for (uint16_t i = 0; i < CAPACITY; ++i) {
-				nodes[i].index = i;
-				internal_push(freeNodes, nodes[i]);
-			}
-		}
-
-		LockfreeBoundedStack(const LockfreeBoundedStack&) = delete;
-		LockfreeBoundedStack& operator=(const LockfreeBoundedStack&) = delete;
-
-		bool pop(T& ret) noexcept {
-			if (auto node = internal_pop(head)) {
-				ret = std::move(getPayload(node));
-				internal_push(freeNodes, node);
-				return true;
-			}
-
-			return false; //The stack was empty
-		}
-
-		bool push(T value) noexcept {
-			if (auto node = internal_pop(freeNodes)) {
-				getPayload(node) = value;
-				internal_push(head, node);
-				return true;
-			}
-
-			return false; //Exceeded maximum capacity
-		}
-	private:
-		Node internal_pop(std::atomic<Node>& listHead) noexcept {
-			Node currentHead, nextNode;
-			currentHead = listHead.load(std::memory_order_acquire);
-			do {
-				if (!currentHead) {
-					break;
-				}
-				nextNode = getNextNode(currentHead);
-			} while (!listHead.compare_exchange_weak(currentHead, nextNode,
-								 std::memory_order_release,
-								 std::memory_order_relaxed));
-
-			return currentHead;
-		}
-
-		void internal_push(std::atomic<Node>& listHead, Node newNode) noexcept {
-			auto currentHead = listHead.load(std::memory_order_acquire);
-			newNode.generation++;
-			do {
-				newNode.nextNode = currentHead.index;
-				nodes[newNode.index] = newNode;
-			} while (!listHead.compare_exchange_weak(currentHead, newNode, 
-								 std::memory_order_release,
-								 std::memory_order_relaxed));
-		}
-
-		T& getPayload(Node node) noexcept {
-			return payloads[node.index];
-		}
-
-		Node getNextNode(Node node) const noexcept {
-			if (node.nextNode == Node::END) {
-				return Node();
-			}
-			return nodes[node.nextNode];
-		}
-
-		T payloads[CAPACITY];
-		Node nodes[CAPACITY];
-
-		//TODO: Add padding to prevent these two from being on the same cache line
-		std::atomic<Node> freeNodes;
-		std::atomic<Node> head;
-};
 
 #endif

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -23,48 +23,51 @@
 #include "networkmessage.h"
 #include "connection.h"
 #include "tools.h"
+#include <boost/lockfree/stack.hpp>
+
+const uint16_t OUTPUTMESSAGE_FREE_LIST_CAPACITY = 4096;
 
 class Protocol;
 
-#define OUTPUT_POOL_SIZE 100
-
 class OutputMessage : public NetworkMessage
 {
-	private:
-		OutputMessage();
-
 	public:
+		enum OutputMessageState {
+			STATE_FREE,
+			STATE_ALLOCATED,
+			STATE_ALLOCATED_NO_AUTOSEND,
+		};
+		OutputMessage(const Connection_ptr& connection, const int64_t frame):
+			connection(connection),
+			frame(frame),
+			outputBufferStart(INITIAL_BUFFER_POSITION),
+			state(STATE_FREE) {}
+		
+		OutputMessage() = delete;
 		// non-copyable
 		OutputMessage(const OutputMessage&) = delete;
 		OutputMessage& operator=(const OutputMessage&) = delete;
+		// non-moveable
+		OutputMessage(OutputMessage&&) = delete;
+		OutputMessage& operator=(OutputMessage&&) = delete;
 
 		uint8_t* getOutputBuffer() {
 			return &buffer[outputBufferStart];
 		}
 
 		void writeMessageLength() {
-			add_header<uint16_t>(length);
+			add_header(length);
 		}
 
 		void addCryptoHeader(bool addChecksum) {
 			if (addChecksum) {
-				add_header<uint32_t>(adlerChecksum(buffer + outputBufferStart, length));
+				add_header(adlerChecksum(buffer + outputBufferStart, length));
 			}
 
-			add_header<uint16_t>(length);
+			writeMessageLength();
 		}
 
-		enum OutputMessageState {
-			STATE_FREE,
-			STATE_ALLOCATED,
-			STATE_ALLOCATED_NO_AUTOSEND,
-			STATE_WAITING,
-		};
-
-		Protocol* getProtocol() const {
-			return m_protocol;
-		}
-		Connection_ptr getConnection() const {
+		const Connection_ptr&  getConnection() const {
 			return connection;
 		}
 		int64_t getFrame() const {
@@ -72,14 +75,14 @@ class OutputMessage : public NetworkMessage
 		}
 
 		inline void append(const NetworkMessage& msg) {
-			int32_t msgLen = msg.getLength();
+			auto msgLen = msg.getLength();
 			memcpy(buffer + position, msg.getBuffer() + 8, msgLen);
 			length += msgLen;
 			position += msgLen;
 		}
 
 		inline void append(OutputMessage_ptr msg) {
-			int32_t msgLen = msg->getLength();
+			auto msgLen = msg->getLength();
 			memcpy(buffer + position, msg->getBuffer() + 8, msgLen);
 			length += msgLen;
 			position += msgLen;
@@ -88,45 +91,17 @@ class OutputMessage : public NetworkMessage
 		void setFrame(int64_t new_frame) {
 			frame = new_frame;
 		}
-
 	protected:
 		template <typename T>
 		inline void add_header(T add) {
-			if (sizeof(T) > outputBufferStart) {
-				std::cout << "Error: [OutputMessage::add_header] outputBufferStart(" << outputBufferStart <<
-				          ") < " << sizeof(T) << std::endl;
-				return;
-			}
-
+			assert(outputBufferStart < sizeof(T));
 			outputBufferStart -= sizeof(T);
 			*reinterpret_cast<T*>(buffer + outputBufferStart) = add;
 			//added header size to the message size
 			length += sizeof(T);
 		}
 
-		void freeMessage() {
-			setConnection(Connection_ptr());
-			setProtocol(nullptr);
-			frame = 0;
-
-			// Allocate enough size for headers:
-			// 2 bytes for unencrypted message size
-			// 4 bytes for checksum
-			// 2 bytes for encrypted message size
-			outputBufferStart = 8;
-
-			//setState have to be the last one
-			setState(OutputMessage::STATE_FREE);
-		}
-
 		friend class OutputMessagePool;
-
-		void setProtocol(Protocol* protocol) {
-			m_protocol = protocol;
-		}
-		void setConnection(Connection_ptr newConnection) {
-			connection = newConnection;
-		}
 
 		void setState(OutputMessageState newState) {
 			state = newState;
@@ -136,10 +111,9 @@ class OutputMessage : public NetworkMessage
 		}
 
 		Connection_ptr connection;
-		Protocol* m_protocol;
 
 		int64_t frame;
-		uint32_t outputBufferStart;
+		MsgSize_t outputBufferStart;
 
 		OutputMessageState state;
 };
@@ -150,8 +124,6 @@ class OutputMessagePool
 		OutputMessagePool();
 
 	public:
-		~OutputMessagePool();
-
 		// non-copyable
 		OutputMessagePool(const OutputMessagePool&) = delete;
 		OutputMessagePool& operator=(const OutputMessagePool&) = delete;
@@ -161,34 +133,31 @@ class OutputMessagePool
 			return &instance;
 		}
 
-		void send(OutputMessage_ptr msg);
+		void send(const OutputMessage_ptr& msg) const;
 		void sendAll();
 		void stop() {
 			m_open = false;
 		}
-		OutputMessage_ptr getOutputMessage(Protocol* protocol, bool autosend = true);
+
+		OutputMessage_ptr getOutputMessage(const Protocol_ptr& protocol, const bool autosend);
+		std::vector<OutputMessage_ptr> getOutputMessages(const std::vector< Protocol_ptr >& protocols);
 		void startExecutionFrame();
 
 		int64_t getFrameTime() const {
 			return frameTime;
 		}
 
-		void addToAutoSend(OutputMessage_ptr msg);
+		void addToAutoSend(const OutputMessage_ptr& msg);
 
 	protected:
-		void configureOutputMessage(OutputMessage_ptr msg, Protocol* protocol, bool autosend);
-		void releaseMessage(OutputMessage* msg);
-		void internalReleaseMessage(OutputMessage* msg);
-
-		typedef std::list<OutputMessage*> InternalOutputMessageList;
-		typedef std::list<OutputMessage_ptr> OutputMessageMessageList;
-
-		InternalOutputMessageList outputMessages;
-		InternalOutputMessageList allOutputMessages;
-		OutputMessageMessageList autoSendOutputMessages;
-		OutputMessageMessageList toAddQueue;
-		std::recursive_mutex outputPoolLock;
-		int64_t frameTime;
-		bool m_open;
+		typedef std::list<OutputMessage_ptr> OutputMessageList;
+		OutputMessage_ptr internalGetMessage(const Connection_ptr& connection, const bool autosend);
+		void internalSend(const OutputMessage_ptr& msg) const;
+		OutputMessageList autoSendOutputMessages;
+		OutputMessageList toAddQueue;
+		std::mutex outputPoolLock;
+		std::atomic<int64_t> frameTime;
+		std::atomic<bool> m_open;
 };
+
 #endif

--- a/src/outputmessage.h
+++ b/src/outputmessage.h
@@ -38,7 +38,7 @@ class OutputMessage : public NetworkMessage
 			STATE_ALLOCATED,
 			STATE_ALLOCATED_NO_AUTOSEND,
 		};
-		OutputMessage(const Connection_ptr& connection, const int64_t frame):
+		OutputMessage(Connection_ptr&& connection, const int64_t frame):
 			connection(connection),
 			frame(frame),
 			outputBufferStart(INITIAL_BUFFER_POSITION),
@@ -152,7 +152,7 @@ class OutputMessagePool
 
 	protected:
 		typedef std::list<OutputMessage_ptr> OutputMessageList;
-		OutputMessage_ptr internalGetMessage(const Connection_ptr& connection, const bool autosend);
+		OutputMessage_ptr internalGetMessage(Connection_ptr&& connection, const bool autosend);
 		void internalSend(const OutputMessage_ptr& msg) const;
 		OutputMessageList autoSendOutputMessages;
 		OutputMessageList toAddQueue;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -56,10 +56,6 @@ Player::Player(ProtocolGame_ptr p) :
 	client = p;
 	isConnecting = false;
 
-	if (client) {
-		client->setPlayer(this);
-	}
-
 	accountNumber = 0;
 	setVocation(0);
 	capacity = 40000;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -50,7 +50,7 @@ MuteCountMap Player::muteCountMap;
 
 uint32_t Player::playerAutoID = 0x10000000;
 
-Player::Player(ProtocolGame* p) :
+Player::Player(ProtocolGame_ptr p) :
 	Creature(), inventory(), varSkills(), varStats(), inventoryAbilities()
 {
 	client = p;

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -771,7 +771,7 @@ void Player::addStorageValue(const uint32_t key, const int32_t value, const bool
 		storageMap[key] = value;
 
 		if (!isLogin) {
-			int64_t currentFrameTime = OutputMessagePool::getInstance()->getFrameTime();
+			int64_t currentFrameTime = OTSYS_TIME();
 			if (lastQuestlogUpdate != currentFrameTime && g_game.quests.isQuestStorage(key, value, oldValue)) {
 				lastQuestlogUpdate = currentFrameTime;
 				sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your questlog has been updated.");

--- a/src/player.h
+++ b/src/player.h
@@ -127,7 +127,7 @@ typedef std::map<uint32_t, uint32_t> MuteCountMap;
 class Player final : public Creature, public Cylinder
 {
 	public:
-		explicit Player(ProtocolGame* p);
+		explicit Player(ProtocolGame_ptr p);
 		~Player();
 
 		// non-copyable
@@ -1241,7 +1241,7 @@ class Player final : public Creature, public Cylinder
 		Npc* shopOwner;
 		Party* party;
 		Player* tradePartner;
-		ProtocolGame* client;
+		ProtocolGame_ptr client;
 		SchedulerTask* walkTask;
 		Town* town;
 		Vocation* vocation;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -133,7 +133,7 @@ bool Protocol::RSA_decrypt(NetworkMessage& msg)
 	return msg.getByte() == 0;
 }
 
-uint32_t Protocol::getIP()
+uint32_t Protocol::getIP() const
 {
 	if (auto connection = getConnection()) {
 		return connection->getIP();

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -27,7 +27,7 @@
 
 extern RSA g_RSA;
 
-void Protocol::onSendMessage(const OutputMessage_ptr& msg)
+void Protocol::onSendMessage(const OutputMessage_ptr& msg) const
 {
 	if (!m_rawMessages) {
 		msg->writeMessageLength();
@@ -37,8 +37,6 @@ void Protocol::onSendMessage(const OutputMessage_ptr& msg)
 			msg->addCryptoHeader(m_checksumEnabled);
 		}
 	}
-
-	clearOutputBuffer(msg);
 }
 
 void Protocol::onRecvMessage(NetworkMessage& msg)
@@ -56,7 +54,7 @@ OutputMessage_ptr Protocol::getOutputBuffer(int32_t size)
 	if (m_outputBuffer && NetworkMessage::max_protocol_body_length >= m_outputBuffer->getLength() + size) {
 		return m_outputBuffer;
 	} else {
-		m_outputBuffer = requestOutputMessage();
+		m_outputBuffer = OutputMessagePool::getOutputMessage();
 		return m_outputBuffer;
 	}
 }
@@ -143,9 +141,3 @@ uint32_t Protocol::getIP()
 
 	return 0;
 }
-
-OutputMessage_ptr Protocol::requestOutputMessage(const bool autosend)
-{
-	return OutputMessagePool::getInstance()->getOutputMessage(shared_from_this(), autosend);
-}
-

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -43,7 +43,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 			return m_connection.lock();
 		}
 
-		uint32_t getIP();
+		uint32_t getIP() const;
 
 		//Use this function for autosend messages only
 		OutputMessage_ptr getOutputBuffer(int32_t size);
@@ -70,7 +70,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 			m_encryptionEnabled = false;
 		}
 		void setXTEAKey(const uint32_t* key) {
-			memcpy(m_key, key, sizeof(uint32_t) * 4);
+			memcpy(m_key, key, sizeof(*key) * 4);
 		}
 		void enableChecksum() {
 			m_checksumEnabled = true;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -34,7 +34,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 
 		virtual void parsePacket(NetworkMessage&) {}
 
-		virtual void onSendMessage(const OutputMessage_ptr& msg);
+		virtual void onSendMessage(const OutputMessage_ptr& msg) const;
 		void onRecvMessage(NetworkMessage& msg);
 		virtual void onRecvFirstMessage(NetworkMessage& msg) = 0;
 		virtual void onConnect() {}
@@ -47,11 +47,14 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 
 		//Use this function for autosend messages only
 		OutputMessage_ptr getOutputBuffer(int32_t size);
-
-		OutputMessage_ptr requestOutputMessage(const bool autosend = true);
-		void clearOutputBuffer(const OutputMessage_ptr& msg) {
-			if (msg == m_outputBuffer) {
-				m_outputBuffer.reset();
+		
+		OutputMessage_ptr& getCurrentBuffer() {
+			return m_outputBuffer;
+		}
+		
+		void send(OutputMessage_ptr msg) {
+			if (auto connection = getConnection()) {
+				connection->send(msg);
 			}
 		}
 	protected:

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -52,7 +52,7 @@ class Protocol : public std::enable_shared_from_this<Protocol>
 			return m_outputBuffer;
 		}
 		
-		void send(OutputMessage_ptr msg) {
+		void send(OutputMessage_ptr msg) const {
 			if (auto connection = getConnection()) {
 				connection->send(msg);
 			}

--- a/src/protocolgame.cpp
+++ b/src/protocolgame.cpp
@@ -47,15 +47,14 @@
 #include "creatureevent.h"
 #include "scheduler.h"
 
-extern Game g_game;
 extern ConfigManager g_config;
 extern Actions actions;
 extern CreatureEvents* g_creatureEvents;
 extern Chat* g_chat;
 
 // Helping templates to add dispatcher tasks
-template<class FunctionType>
-void ProtocolGame::addGameTaskInternal(bool droppable, uint32_t delay, const FunctionType& func)
+template<bool droppable, class FunctionType>
+void ProtocolGame::addGameTaskInternal(uint32_t delay, FunctionType func)
 {
 	if (droppable) {
 		g_dispatcher.addTask(createTask(delay, func));

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -316,22 +316,14 @@ class ProtocolGame final : public Protocol
 		// Helpers so we don't need to bind every time
 		template <typename Callable, typename... Args>
 		void addGameTask(Callable function, Args&&... args) {
-			addGameTaskInternal<false>(0, std::bind(function, &g_game, std::forward<Args>(args)...));
+			g_dispatcher.addTask(createTask(std::bind(function, &g_game, std::forward<Args>(args)...)));
 		}
 		
 		template <typename Callable, typename... Args>
 		void addGameTaskTimed(uint32_t delay, Callable function, Args&&... args) {
-			addGameTaskInternal<true>(delay, std::bind(function, &g_game, std::forward<Args>(args)...));
+			g_dispatcher.addTask(createTask(delay, std::bind(function, &g_game, std::forward<Args>(args)...)));
 		}
 
-		template<bool droppable, class FunctionType>
-		static void addGameTaskInternal(uint32_t delay, FunctionType func) {
-			if (droppable) {
-				g_dispatcher.addTask(createTask(delay, func));
-			} else {
-				g_dispatcher.addTask(createTask(func));
-			}
-		}
 		
 		std::unordered_set<uint32_t> knownCreatureSet;
 		Player* player;

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -32,6 +32,8 @@ class Container;
 class Tile;
 class Connection;
 class Quest;
+class ProtocolGame;
+typedef std::shared_ptr<ProtocolGame> ProtocolGame_ptr;
 
 struct TextMessage
 {
@@ -77,14 +79,14 @@ class ProtocolGame final : public Protocol
 
 	private:
 		std::unordered_set<uint32_t> knownCreatureSet;
-
+		ProtocolGame_ptr getThis() {
+			return std::dynamic_pointer_cast<ProtocolGame>(shared_from_this());
+		}
 		void connect(uint32_t playerId, OperatingSystem_t operatingSystem);
-		void disconnect() const;
 		void disconnectClient(const std::string& message);
 		void writeToOutputBuffer(const NetworkMessage& msg);
 
-		void releaseProtocol() final;
-		void deleteProtocolTask() final;
+		void release() final;
 
 		void checkCreatureAsKnown(uint32_t id, bool& known, uint32_t& removedKnown);
 

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -316,12 +316,12 @@ class ProtocolGame final : public Protocol
 
 		// Helpers so we don't need to bind every time
 		template <typename Callable, typename... Args>
-		void addGameTask(Callable function, Args... args) {
+		void addGameTask(Callable function, Args&&... args) {
 			addGameTaskInternal<false>(0, std::bind(function, &g_game, std::forward<Args>(args)...));
 		}
 		
 		template <typename Callable, typename... Args>
-		void addGameTaskTimed(uint32_t delay, Callable function, Args... args) {
+		void addGameTaskTimed(uint32_t delay, Callable function, Args&&... args) {
 			addGameTaskInternal<true>(delay, std::bind(function, &g_game, std::forward<Args>(args)...));
 		}
 

--- a/src/protocolgame.h
+++ b/src/protocolgame.h
@@ -23,6 +23,7 @@
 #include "protocol.h"
 #include "chat.h"
 #include "creature.h"
+#include "tasks.h"
 
 class NetworkMessage;
 class Player;
@@ -73,8 +74,6 @@ class ProtocolGame final : public Protocol
 		void login(const std::string& name, uint32_t accnumber, OperatingSystem_t operatingSystem);
 		void logout(bool displayEffect, bool forced);
 
-		void setPlayer(Player* p);
-
 		uint16_t getVersion() const {
 			return version;
 		}
@@ -84,7 +83,7 @@ class ProtocolGame final : public Protocol
 			return std::dynamic_pointer_cast<ProtocolGame>(shared_from_this());
 		}
 		void connect(uint32_t playerId, OperatingSystem_t operatingSystem);
-		void disconnectClient(const std::string& message);
+		void disconnectClient(const std::string& message) const;
 		void writeToOutputBuffer(const NetworkMessage& msg);
 
 		void release() final;
@@ -326,7 +325,13 @@ class ProtocolGame final : public Protocol
 		}
 
 		template<bool droppable, class FunctionType>
-		static void addGameTaskInternal(uint32_t delay, FunctionType func);
+		static void addGameTaskInternal(uint32_t delay, FunctionType func) {
+			if (droppable) {
+				g_dispatcher.addTask(createTask(delay, func));
+			} else {
+				g_dispatcher.addTask(createTask(func));
+			}
+		}
 		
 		std::unordered_set<uint32_t> knownCreatureSet;
 		Player* player;

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -37,14 +37,14 @@ extern Game g_game;
 
 void ProtocolLogin::disconnectClient(const std::string& message, uint16_t version)
 {
-	OutputMessage_ptr output = OutputMessagePool::getInstance()->getOutputMessage(this, false);
+	OutputMessage_ptr output = requestOutputMessage(false);
 	if (output) {
 		output->addByte(version >= 1076 ? 0x0B : 0x0A);
 		output->addString(message);
 		OutputMessagePool::getInstance()->send(output);
 	}
 
-	getConnection()->close();
+	disconnect();
 }
 
 void ProtocolLogin::getCharacterList(const std::string& accountName, const std::string& password, uint16_t version)
@@ -55,7 +55,7 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 		return;
 	}
 
-	OutputMessage_ptr output = OutputMessagePool::getInstance()->getOutputMessage(this, false);
+	OutputMessage_ptr output = requestOutputMessage(false);
 	if (output) {
 		//Update premium days
 		Game::updatePremium(account);
@@ -99,13 +99,13 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 		OutputMessagePool::getInstance()->send(output);
 	}
 
-	getConnection()->close();
+	disconnect();
 }
 
 void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 {
 	if (g_game.getGameState() == GAME_STATE_SHUTDOWN) {
-		getConnection()->close();
+		disconnect();
 		return;
 	}
 
@@ -124,7 +124,9 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	 * 1 byte: 0
 	 */
 
-#define dispatchDisconnectClient(err) g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::disconnectClient, this, err, version)))
+	auto dispatchDisconnectClient = [this, version](const std::string& err) {
+		g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::disconnectClient, std::dynamic_pointer_cast<ProtocolLogin>(shared_from_this()), err, version)));
+	};
 
 	if (version <= 760) {
 		dispatchDisconnectClient("Only clients with protocol " CLIENT_VERSION_STR " allowed!");
@@ -132,7 +134,7 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	if (!Protocol::RSA_decrypt(msg)) {
-		getConnection()->close();
+		disconnect();
 		return;
 	}
 
@@ -177,8 +179,6 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 		return;
 	}
 
-#undef dispatchDisconnectClient
-
 	std::string password = msg.getString();
-	g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::getCharacterList, this, accountName, password, version)));
+	g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::getCharacterList, std::dynamic_pointer_cast<ProtocolLogin>(shared_from_this()), accountName, password, version)));
 }

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -37,11 +37,11 @@ extern Game g_game;
 
 void ProtocolLogin::disconnectClient(const std::string& message, uint16_t version)
 {
-	OutputMessage_ptr output = requestOutputMessage(false);
+	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
 	if (output) {
 		output->addByte(version >= 1076 ? 0x0B : 0x0A);
 		output->addString(message);
-		OutputMessagePool::getInstance()->send(output);
+		send(output);
 	}
 
 	disconnect();
@@ -55,49 +55,47 @@ void ProtocolLogin::getCharacterList(const std::string& accountName, const std::
 		return;
 	}
 
-	OutputMessage_ptr output = requestOutputMessage(false);
-	if (output) {
-		//Update premium days
-		Game::updatePremium(account);
+	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
+	//Update premium days
+	Game::updatePremium(account);
 
-		//Add MOTD
-		output->addByte(0x14);
+	//Add MOTD
+	output->addByte(0x14);
 
-		std::ostringstream ss;
-		ss << g_game.getMotdNum() << "\n" << g_config.getString(ConfigManager::MOTD);
-		output->addString(ss.str());
+	std::ostringstream ss;
+	ss << g_game.getMotdNum() << "\n" << g_config.getString(ConfigManager::MOTD);
+	output->addString(ss.str());
 
-		//Add session key
-		output->addByte(0x28);
-		output->addString(accountName + "\n" + password);
+	//Add session key
+	output->addByte(0x28);
+	output->addString(accountName + "\n" + password);
 
-		//Add char list
-		output->addByte(0x64);
+	//Add char list
+	output->addByte(0x64);
 
-		output->addByte(1); // number of worlds
+	output->addByte(1); // number of worlds
 
-		output->addByte(0); // world id
-		output->addString(g_config.getString(ConfigManager::SERVER_NAME));
-		output->addString(g_config.getString(ConfigManager::IP));
-		output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
+	output->addByte(0); // world id
+	output->addString(g_config.getString(ConfigManager::SERVER_NAME));
+	output->addString(g_config.getString(ConfigManager::IP));
+	output->add<uint16_t>(g_config.getNumber(ConfigManager::GAME_PORT));
+	output->addByte(0);
+
+	uint8_t size = std::min<size_t>(std::numeric_limits<uint8_t>::max(), account.characters.size());
+	output->addByte(size);
+	for (uint8_t i = 0; i < size; i++) {
 		output->addByte(0);
-
-		uint8_t size = std::min<size_t>(std::numeric_limits<uint8_t>::max(), account.characters.size());
-		output->addByte(size);
-		for (uint8_t i = 0; i < size; i++) {
-			output->addByte(0);
-			output->addString(account.characters[i]);
-		}
-
-		//Add premium days
-		if (g_config.getBoolean(ConfigManager::FREE_PREMIUM)) {
-			output->add<uint16_t>(0xFFFF);    //client displays free premium
-		} else {
-			output->add<uint16_t>(account.premiumDays);
-		}
-
-		OutputMessagePool::getInstance()->send(output);
+		output->addString(account.characters[i]);
 	}
+
+	//Add premium days
+	if (g_config.getBoolean(ConfigManager::FREE_PREMIUM)) {
+		output->add<uint16_t>(0xFFFF);    //client displays free premium
+	} else {
+		output->add<uint16_t>(account.premiumDays);
+	}
+
+	send(output);
 
 	disconnect();
 }

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -125,7 +125,8 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	 */
 
 	auto dispatchDisconnectClient = [this, version](const std::string& err) {
-		g_dispatcher.addTask(createTask(std::bind(&ProtocolLogin::disconnectClient, std::dynamic_pointer_cast<ProtocolLogin>(shared_from_this()), err, version)));
+		g_dispatcher.addTask(createTask(
+			std::bind(&ProtocolLogin::disconnectClient, std::dynamic_pointer_cast<ProtocolLogin>(shared_from_this()), err, version)));
 	};
 
 	if (version <= 760) {

--- a/src/protocollogin.cpp
+++ b/src/protocollogin.cpp
@@ -162,7 +162,11 @@ void ProtocolLogin::onRecvFirstMessage(NetworkMessage& msg)
 	}
 
 	BanInfo banInfo;
-	if (IOBan::isIpBanned(getConnection()->getIP(), banInfo)) {
+	auto connection = getConnection();
+	if (!connection) {
+		return;
+	}
+	if (IOBan::isIpBanned(connection->getIP(), banInfo)) {
 		if (banInfo.reason.empty()) {
 			banInfo.reason = "(none)";
 		}

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -31,12 +31,10 @@ extern Game g_game;
 
 void ProtocolOld::dispatchedDisconnectClient(const std::string& message)
 {
-	OutputMessage_ptr output = requestOutputMessage(false);
-	if (output) {
-		output->addByte(0x0A);
-		output->addString(message);
-		OutputMessagePool::getInstance()->send(output);
-	}
+	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
+	output->addByte(0x0A);
+	output->addString(message);
+	send(output);
 
 	disconnect();
 }

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -31,7 +31,7 @@ extern Game g_game;
 
 void ProtocolOld::disconnectClient(const std::string& message)
 {
-	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
+	auto output = OutputMessagePool::getOutputMessage();
 	output->addByte(0x0A);
 	output->addString(message);
 	send(output);

--- a/src/protocolold.cpp
+++ b/src/protocolold.cpp
@@ -29,7 +29,7 @@
 
 extern Game g_game;
 
-void ProtocolOld::dispatchedDisconnectClient(const std::string& message)
+void ProtocolOld::disconnectClient(const std::string& message)
 {
 	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
 	output->addByte(0x0A);
@@ -37,11 +37,6 @@ void ProtocolOld::dispatchedDisconnectClient(const std::string& message)
 	send(output);
 
 	disconnect();
-}
-
-void ProtocolOld::disconnectClient(const std::string& message)
-{
-	g_dispatcher.addTask(createTask(std::bind(&ProtocolOld::dispatchedDisconnectClient, std::dynamic_pointer_cast<ProtocolOld>(shared_from_this()), message)));
 }
 
 void ProtocolOld::onRecvFirstMessage(NetworkMessage& msg)

--- a/src/protocolold.h
+++ b/src/protocolold.h
@@ -41,7 +41,6 @@ class ProtocolOld final : public Protocol
 		void onRecvFirstMessage(NetworkMessage& msg) final;
 
 	protected:
-		void dispatchedDisconnectClient(const std::string& message);
 		void disconnectClient(const std::string& message);
 };
 

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -65,7 +65,8 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 		//XML info protocol
 		case 0xFF: {
 			if (msg.getString(4) == "info") {
-				g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendStatusString, std::dynamic_pointer_cast<ProtocolStatus>(shared_from_this()))));
+				g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendStatusString, 
+									  std::dynamic_pointer_cast<ProtocolStatus>(shared_from_this()))));
 				return;
 			}
 			break;
@@ -78,7 +79,8 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 			if (requestedInfo & REQUEST_PLAYER_STATUS_INFO) {
 				characterName = msg.getString();
 			}
-			g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendInfo, std::dynamic_pointer_cast<ProtocolStatus>(shared_from_this()), requestedInfo, characterName)));
+			g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendInfo, std::dynamic_pointer_cast<ProtocolStatus>(shared_from_this()), 
+								  requestedInfo, characterName)));
 			return;
 		}
 
@@ -91,10 +93,6 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 void ProtocolStatus::sendStatusString()
 {
 	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
-	if (!output) {
-		disconnect();
-		return;
-	}
 
 	setRawMessages(true);
 

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -92,7 +92,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 
 void ProtocolStatus::sendStatusString()
 {
-	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
+	auto output = OutputMessagePool::getOutputMessage();
 
 	setRawMessages(true);
 
@@ -160,7 +160,7 @@ void ProtocolStatus::sendStatusString()
 
 void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& characterName)
 {
-	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
+	auto output = OutputMessagePool::getOutputMessage();
 
 	if (requestedInfo & REQUEST_BASIC_SERVER_INFO) {
 		output->addByte(0x10);

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -53,9 +53,8 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 		if (ipStr != g_config.getString(ConfigManager::IP)) {
 			std::map<uint32_t, int64_t>::const_iterator it = ipConnectMap.find(ip);
 			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_config.getNumber(ConfigManager::STATUSQUERY_TIMEOUT)))) {
-				getConnection()->close();
+				disconnect();
 				return;
-			}
 		}
 	}
 
@@ -65,7 +64,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 		//XML info protocol
 		case 0xFF: {
 			if (msg.getString(4) == "info") {
-				g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendStatusString, this)));
+				g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendStatusString, std::dynamic_pointer_cast<ProtocolStatus>(shared_from_this()))));
 				return;
 			}
 			break;
@@ -78,21 +77,21 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 			if (requestedInfo & REQUEST_PLAYER_STATUS_INFO) {
 				characterName = msg.getString();
 			}
-			g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendInfo, this, requestedInfo, characterName)));
+			g_dispatcher.addTask(createTask(std::bind(&ProtocolStatus::sendInfo, std::dynamic_pointer_cast<ProtocolStatus>(shared_from_this()), requestedInfo, characterName)));
 			return;
 		}
 
 		default:
 			break;
 	}
-	getConnection()->close();
+	disconnect();
 }
 
 void ProtocolStatus::sendStatusString()
 {
-	OutputMessage_ptr output = OutputMessagePool::getInstance()->getOutputMessage(this, false);
+	OutputMessage_ptr output = requestOutputMessage(false);
 	if (!output) {
-		getConnection()->close();
+		disconnect();
 		return;
 	}
 
@@ -155,17 +154,16 @@ void ProtocolStatus::sendStatusString()
 	std::ostringstream ss;
 	doc.save(ss, "", pugi::format_raw);
 
-	std::string data = ss.str();
-	output->addBytes(data.c_str(), data.size());
+	output->addString(ss.str());
 	OutputMessagePool::getInstance()->send(output);
-	getConnection()->close();
+	disconnect();
 }
 
 void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& characterName)
 {
-	OutputMessage_ptr output = OutputMessagePool::getInstance()->getOutputMessage(this, false);
+	OutputMessage_ptr output = requestOutputMessage(false);
 	if (!output) {
-		getConnection()->close();
+		disconnect();
 		return;
 	}
 
@@ -234,5 +232,5 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 		output->addString(CLIENT_VERSION_STR);
 	}
 	OutputMessagePool::getInstance()->send(output);
-	getConnection()->close();
+	disconnect();
 }

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -55,6 +55,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 			if (it != ipConnectMap.end() && (OTSYS_TIME() < (it->second + g_config.getNumber(ConfigManager::STATUSQUERY_TIMEOUT)))) {
 				disconnect();
 				return;
+			}
 		}
 	}
 

--- a/src/protocolstatus.cpp
+++ b/src/protocolstatus.cpp
@@ -90,7 +90,7 @@ void ProtocolStatus::onRecvFirstMessage(NetworkMessage& msg)
 
 void ProtocolStatus::sendStatusString()
 {
-	OutputMessage_ptr output = requestOutputMessage(false);
+	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
 	if (!output) {
 		disconnect();
 		return;
@@ -156,17 +156,13 @@ void ProtocolStatus::sendStatusString()
 	doc.save(ss, "", pugi::format_raw);
 
 	output->addString(ss.str());
-	OutputMessagePool::getInstance()->send(output);
+	send(output);
 	disconnect();
 }
 
 void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& characterName)
 {
-	OutputMessage_ptr output = requestOutputMessage(false);
-	if (!output) {
-		disconnect();
-		return;
-	}
+	OutputMessage_ptr output = OutputMessagePool::getOutputMessage();
 
 	if (requestedInfo & REQUEST_BASIC_SERVER_INFO) {
 		output->addByte(0x10);
@@ -232,6 +228,6 @@ void ProtocolStatus::sendInfo(uint16_t requestedInfo, const std::string& charact
 		output->addString(STATUS_SERVER_VERSION);
 		output->addString(CLIENT_VERSION_STR);
 	}
-	OutputMessagePool::getInstance()->send(output);
+	send(output);
 	disconnect();
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -170,7 +170,7 @@ Protocol_ptr ServicePort::make_protocol(bool checksummed, NetworkMessage& msg, c
 		}
 
 		if ((checksummed && service->is_checksummed()) || !service->is_checksummed()) {
-			return service->make_protocol(Connection_ptr());
+			return service->make_protocol(connection);
 		}
 	}
 	return nullptr;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -71,8 +71,6 @@ void ServiceManager::stop()
 
 	m_acceptors.clear();
 
-	OutputMessagePool::getInstance()->stop();
-
 	death_timer.expires_from_now(boost::posix_time::seconds(3));
 	death_timer.async_wait(std::bind(&ServiceManager::die, this));
 }
@@ -137,7 +135,7 @@ void ServicePort::onAccept(boost::asio::ip::tcp::socket* socket, const boost::sy
 		}
 
 		if (remote_ip != 0 && g_bans.acceptConnection(remote_ip)) {
-			Connection_ptr connection = ConnectionManager::getInstance()->createConnection(socket, m_io_service, shared_from_this());
+			Connection_ptr connection = ConnectionManager::getInstance().createConnection(socket, m_io_service, shared_from_this());
 			Service_ptr service = m_services.front();
 			if (service->is_single_socket()) {
 				connection->accept(service->make_protocol(connection));

--- a/src/server.h
+++ b/src/server.h
@@ -133,14 +133,14 @@ bool ServiceManager::add(uint16_t port)
 
 	ServicePort_ptr service_port;
 
-	auto finder = m_acceptors.find(port);
+	auto foundServicePort = m_acceptors.find(port);
 
-	if (finder == m_acceptors.end()) {
+	if (foundServicePort == m_acceptors.end()) {
 		service_port = std::make_shared<ServicePort>(m_io_service);
 		service_port->open(port);
 		m_acceptors[port] = service_port;
 	} else {
-		service_port = finder->second;
+		service_port = foundServicePort->second;
 
 		if (service_port->is_single_socket() || ProtocolType::server_sends_first) {
 			std::cout << "ERROR: " << ProtocolType::protocol_name() <<

--- a/src/server.h
+++ b/src/server.h
@@ -116,7 +116,7 @@ class ServiceManager
 	protected:
 		void die();
 
-		std::map<uint16_t, ServicePort_ptr> m_acceptors;
+		std::unordered_map<uint16_t, ServicePort_ptr> m_acceptors;
 
 		boost::asio::io_service m_io_service;
 		boost::asio::deadline_timer death_timer;

--- a/src/tasks.cpp
+++ b/src/tasks.cpp
@@ -38,7 +38,7 @@ void Dispatcher::start()
 
 void Dispatcher::dispatcherThread()
 {
-	OutputMessagePool* outputPool = OutputMessagePool::getInstance();
+	auto& outputPool = OutputMessagePool::getInstance();
 
 	// NOTE: second argument defer_lock is to prevent from immediate locking
 	std::unique_lock<std::mutex> taskLockUnique(taskLock, std::defer_lock);
@@ -60,9 +60,8 @@ void Dispatcher::dispatcherThread()
 
 			if (!task->hasExpired()) {
 				// execute it
-				outputPool->startExecutionFrame();
 				(*task)();
-				outputPool->sendAll();
+				outputPool.sendAll();
 
 				g_game.map.clearSpectatorCache();
 			}
@@ -107,10 +106,7 @@ void Dispatcher::flush()
 		(*task)();
 		delete task;
 
-		OutputMessagePool* outputPool = OutputMessagePool::getInstance();
-		if (outputPool) {
-			outputPool->sendAll();
-		}
+		OutputMessagePool::getInstance().sendAll();
 
 		g_game.map.clearSpectatorCache();
 	}


### PR DESCRIPTION
Refactor OutputMessagePool. Remove ref counter from Connection as it's really unnecessary since, we're already doing the same with the shared_ptr created by inheriting from enable_shared_from_this. Move socket cleanup code calling to the Connection destructor. Remove getAvailableMessageCount() and getAutoMessageCount() from OutputMessagePool as these were not thread-safe and unused anyway. Protocol objects are now managed by shared_ptrs. Rename member variables. Made some small code improvements for better readability. I did some performance testing (with a Release build) and time spent in getOutputMessage() dropped by 40% on average (bear in mind that it's under light load, my version of that function scales better as contention on new/delete increases (the old version would always allocate memory for the shared_ptr control block.